### PR TITLE
microlc fe passes shared props to qiankun

### DIFF
--- a/packages/core/src/models/configuration/Configuration.ts
+++ b/packages/core/src/models/configuration/Configuration.ts
@@ -17,14 +17,16 @@ import {FromSchema} from 'json-schema-to-ts'
 
 import {analyticsSchema} from './analytics/Analytics'
 import {helpMenuSchema} from './helpMenu/HelpMenu'
-import {pluginRecursiveSchema, pluginSchema} from './plugin/Plugin'
-import {themingSchema} from './theming/Theming'
 import {internalPluginSchema} from './plugin/InternalPlugin'
+import {pluginRecursiveSchema, pluginSchema} from './plugin/Plugin'
+import {sharedSchema} from './shared/Shared'
+import {themingSchema} from './theming/Theming'
 
 export const configurationSchema = {
   type: 'object',
   properties: {
     theming: themingSchema,
+    shared: sharedSchema,
     plugins: {
       type: 'array',
       items: pluginSchema,
@@ -42,6 +44,7 @@ export const configurationRecursiveSchema = {
   type: 'object',
   properties: {
     theming: themingSchema,
+    shared: sharedSchema,
     plugins: {
       type: 'array',
       items: pluginRecursiveSchema,

--- a/packages/core/src/models/configuration/shared/Shared.ts
+++ b/packages/core/src/models/configuration/shared/Shared.ts
@@ -20,7 +20,6 @@ export const sharedSchema = {
   properties: {
     props: {
       type: 'object',
-      additionalProperties: true,
     },
   },
 } as const

--- a/packages/core/src/models/configuration/shared/Shared.ts
+++ b/packages/core/src/models/configuration/shared/Shared.ts
@@ -13,14 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './Configuration'
-export * from './plugin/ExternalLink'
-export * from './plugin/Plugin'
-export * from './plugin/InternalPlugin'
-export * from './theming/Header'
-export * from './helpMenu/HelpMenu'
-export * from './theming/Logo'
-export * from './theming/Theming'
-export * from './shared/Shared'
-export * from './analytics/Analytics'
-export * from './theming/Variables'
+import {FromSchema} from 'json-schema-to-ts'
+
+export const sharedSchema = {
+  type: 'object',
+  properties: {
+    props: {
+      type: 'object',
+      additionalProperties: true,
+    },
+  },
+} as const
+
+export type Shared = FromSchema<typeof sharedSchema>

--- a/packages/fe-container/src/hooks/useAppData/useAppData.test.ts
+++ b/packages/fe-container/src/hooks/useAppData/useAppData.test.ts
@@ -153,7 +153,7 @@ describe('Test useAppData hook', () => {
     // @ts-ignore
     expect(registerPlugin.mock.calls[3][0]).toMatchObject(pluginInternal1)
     expect(registerPlugin).toHaveBeenCalledTimes(4)
-    expect(finish).toHaveBeenCalledWith(user, {})
+    expect(finish).toHaveBeenCalledWith(user, undefined)
     expect(isCurrentPluginLoaded).toHaveBeenCalled()
     expect(result.current).toMatchObject(expectedState)
   })

--- a/packages/fe-container/src/hooks/useAppData/useAppData.test.ts
+++ b/packages/fe-container/src/hooks/useAppData/useAppData.test.ts
@@ -23,7 +23,7 @@ import {useAppData} from '@hooks/useAppData/useAppData'
 nock.disableNetConnect()
 
 jest.mock('@utils/plugins/PluginsLoaderFacade', () => ({
-  finish: jest.fn((param) => {
+  finish: jest.fn((param, shared) => {
   }),
   isCurrentPluginLoaded: jest.fn(() => false),
   registerPlugin: jest.fn((param) => {
@@ -153,7 +153,7 @@ describe('Test useAppData hook', () => {
     // @ts-ignore
     expect(registerPlugin.mock.calls[3][0]).toMatchObject(pluginInternal1)
     expect(registerPlugin).toHaveBeenCalledTimes(4)
-    expect(finish).toHaveBeenCalledWith(user)
+    expect(finish).toHaveBeenCalledWith(user, {})
     expect(isCurrentPluginLoaded).toHaveBeenCalled()
     expect(result.current).toMatchObject(expectedState)
   })

--- a/packages/fe-container/src/hooks/useAppData/useAppData.ts
+++ b/packages/fe-container/src/hooks/useAppData/useAppData.ts
@@ -39,7 +39,7 @@ const notHref = (plugin: InternalPlugin) => plugin.integrationMode && plugin.int
 
 const registerPlugins = (configuration: Configuration, user: Partial<User>) => {
   [...configuration.plugins || [], ...configuration.internalPlugins || []].sort(pluginsSorter).forEach(registerPlugin)
-  finish(user, configuration.shared || {})
+  finish(user, configuration?.shared)
 }
 
 const navigateToFirstPlugin = () => {

--- a/packages/fe-container/src/hooks/useAppData/useAppData.ts
+++ b/packages/fe-container/src/hooks/useAppData/useAppData.ts
@@ -39,7 +39,7 @@ const notHref = (plugin: InternalPlugin) => plugin.integrationMode && plugin.int
 
 const registerPlugins = (configuration: Configuration, user: Partial<User>) => {
   [...configuration.plugins || [], ...configuration.internalPlugins || []].sort(pluginsSorter).forEach(registerPlugin)
-  finish(user)
+  finish(user, configuration.shared || {})
 }
 
 const navigateToFirstPlugin = () => {

--- a/packages/fe-container/src/utils/plugins/PluginsLoaderFacade.test.ts
+++ b/packages/fe-container/src/utils/plugins/PluginsLoaderFacade.test.ts
@@ -18,7 +18,7 @@ import {Plugin} from '@mia-platform/core'
 
 import {RESERVED_PATH} from '@constants'
 
-import {finish, isCurrentPluginLoaded, registerPlugin, retrievePluginStrategy} from './PluginsLoaderFacade'
+import {finish, isCurrentPluginLoaded, registeredPlugins, registerPlugin, retrievePluginStrategy} from './PluginsLoaderFacade'
 
 jest.mock('qiankun', () => ({
   start: jest.fn(),
@@ -27,6 +27,11 @@ jest.mock('qiankun', () => ({
 }))
 
 describe('Test plugin loading', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+    registeredPlugins.splice(0, registeredPlugins.length)
+  })
+
   it('test href same window', () => {
     // eslint-disable-next-line
     window = Object.create(window)
@@ -115,7 +120,7 @@ describe('Test plugin loading', () => {
     }
     registerPlugin(pluginToRegister)
     retrievePluginStrategy(pluginToRegister).handlePluginLoad()
-    finish({})
+    finish({}, {})
     expect(start).toHaveBeenCalled()
     expect(addErrorHandler).toHaveBeenCalled()
     expect(registerMicroApps).toHaveBeenCalledWith([])
@@ -133,7 +138,7 @@ describe('Test plugin loading', () => {
     }
     registerPlugin(pluginToRegister)
     retrievePluginStrategy(pluginToRegister).handlePluginLoad()
-    finish({})
+    finish({}, {})
     expect(start).toHaveBeenCalled()
     expect(addErrorHandler).toHaveBeenCalled()
     expect(registerMicroApps).toHaveBeenCalledWith([{
@@ -147,6 +152,38 @@ describe('Test plugin loading', () => {
         currentUser: {}
       }
     }])
+  })
+
+  it('test qiankun with shared props', () => {
+    const integrationMode: 'qiankun' = 'qiankun'
+    window.open = jest.fn()
+    const pluginToRegister = {
+      id: 'plugin-1',
+      label: 'Plugin 1',
+      integrationMode,
+      pluginRoute: '/qiankunTest',
+      pluginUrl: 'https://www.google.com/webhp?igu=1'
+    }
+    expect(registeredPlugins).toHaveLength(0)
+    registerPlugin(pluginToRegister)
+    retrievePluginStrategy(pluginToRegister).handlePluginLoad()
+    finish({email: 'email'}, {props: {headers: 'any'}})
+    expect(start).toHaveBeenCalled()
+    expect(addErrorHandler).toHaveBeenCalled()
+    expect(registerMicroApps).toHaveBeenCalledTimes(1)
+    expect(registerMicroApps).toHaveBeenCalledWith([{
+      name: 'plugin-1',
+      entry: 'https://www.google.com/webhp?igu=1',
+      container: '#microlc-qiankun-contaier',
+      activeRule: '/qiankunTest',
+      props: {
+        basePath: '',
+        activeRule: '/qiankunTest',
+        currentUser: {email: 'email'},
+        headers: 'any'
+      }
+    }])
+    expect(registeredPlugins).toHaveLength(1)
   })
 
   it('test undefined plugin route: empty fallback', () => {
@@ -163,7 +200,7 @@ describe('Test plugin loading', () => {
     }
     registerPlugin(pluginToRegister)
     retrievePluginStrategy(pluginToRegister).handlePluginLoad()
-    finish({})
+    finish({}, {})
     expect(start).toHaveBeenCalled()
     expect(addErrorHandler).toHaveBeenCalled()
     expect(registerMicroApps).toHaveBeenCalled()
@@ -203,7 +240,7 @@ describe('Test plugin loading', () => {
     }
     registerPlugin(pluginToRegister)
     retrievePluginStrategy(pluginToRegister).handlePluginLoad()
-    finish({})
+    finish({}, {})
     expect(start).toHaveBeenCalled()
     expect(addErrorHandler).toHaveBeenCalled()
     expect(registerMicroApps.mock.calls[0][0]).toContainEqual({

--- a/packages/fe-container/src/utils/plugins/PluginsLoaderFacade.test.ts
+++ b/packages/fe-container/src/utils/plugins/PluginsLoaderFacade.test.ts
@@ -120,7 +120,7 @@ describe('Test plugin loading', () => {
     }
     registerPlugin(pluginToRegister)
     retrievePluginStrategy(pluginToRegister).handlePluginLoad()
-    finish({}, {})
+    finish({})
     expect(start).toHaveBeenCalled()
     expect(addErrorHandler).toHaveBeenCalled()
     expect(registerMicroApps).toHaveBeenCalledWith([])
@@ -138,7 +138,7 @@ describe('Test plugin loading', () => {
     }
     registerPlugin(pluginToRegister)
     retrievePluginStrategy(pluginToRegister).handlePluginLoad()
-    finish({}, {})
+    finish({})
     expect(start).toHaveBeenCalled()
     expect(addErrorHandler).toHaveBeenCalled()
     expect(registerMicroApps).toHaveBeenCalledWith([{
@@ -200,7 +200,7 @@ describe('Test plugin loading', () => {
     }
     registerPlugin(pluginToRegister)
     retrievePluginStrategy(pluginToRegister).handlePluginLoad()
-    finish({}, {})
+    finish({})
     expect(start).toHaveBeenCalled()
     expect(addErrorHandler).toHaveBeenCalled()
     expect(registerMicroApps).toHaveBeenCalled()
@@ -240,7 +240,7 @@ describe('Test plugin loading', () => {
     }
     registerPlugin(pluginToRegister)
     retrievePluginStrategy(pluginToRegister).handlePluginLoad()
-    finish({}, {})
+    finish({})
     expect(start).toHaveBeenCalled()
     expect(addErrorHandler).toHaveBeenCalled()
     expect(registerMicroApps.mock.calls[0][0]).toContainEqual({

--- a/packages/fe-container/src/utils/plugins/PluginsLoaderFacade.test.ts
+++ b/packages/fe-container/src/utils/plugins/PluginsLoaderFacade.test.ts
@@ -186,6 +186,43 @@ describe('Test plugin loading', () => {
     expect(registeredPlugins).toHaveLength(1)
   })
 
+  it('test qiankun with both shared and plugin props => plugin props must override shared', () => {
+    const integrationMode: 'qiankun' = 'qiankun'
+    window.open = jest.fn()
+    const pluginToRegister = {
+      id: 'plugin-1',
+      label: 'Plugin 1',
+      integrationMode,
+      pluginRoute: '/qiankunTest',
+      pluginUrl: 'https://www.google.com/webhp?igu=1',
+      props: {
+        headers: {
+          'custom-header': 'from-plugin'
+        }
+      }
+    }
+    expect(registeredPlugins).toHaveLength(0)
+    registerPlugin(pluginToRegister)
+    retrievePluginStrategy(pluginToRegister).handlePluginLoad()
+    finish({email: 'email'}, {props: {headers: {'custom-haeder': 'from-qiankun'}}})
+    expect(start).toHaveBeenCalled()
+    expect(addErrorHandler).toHaveBeenCalled()
+    expect(registerMicroApps).toHaveBeenCalledTimes(1)
+    expect(registerMicroApps).toHaveBeenCalledWith([{
+      name: 'plugin-1',
+      entry: 'https://www.google.com/webhp?igu=1',
+      container: '#microlc-qiankun-contaier',
+      activeRule: '/qiankunTest',
+      props: {
+        basePath: '',
+        activeRule: '/qiankunTest',
+        currentUser: {email: 'email'},
+        headers: {'custom-header': 'from-plugin'}
+      }
+    }])
+    expect(registeredPlugins).toHaveLength(1)
+  })
+
   it('test undefined plugin route: empty fallback', () => {
     // @ts-ignore
     const pluginRoute: string = undefined

--- a/packages/fe-container/src/utils/plugins/PluginsLoaderFacade.ts
+++ b/packages/fe-container/src/utils/plugins/PluginsLoaderFacade.ts
@@ -22,6 +22,7 @@ import {noOpStrategy} from '@utils/plugins/strategies/NoOpStrategy'
 import {hrefStrategy} from '@utils/plugins/strategies/HrefStrategy'
 import {routeStrategy} from '@utils/plugins/strategies/RouteStrategy'
 import {PluginStrategy} from '@utils/plugins/strategies/PluginStrategy'
+import {Shared} from '@mia-platform/core/src/models/configuration'
 
 const registeredPluginsStrategies = new Map<string, PluginStrategy>()
 export const registeredPlugins: InternalPlugin[] = []
@@ -66,10 +67,10 @@ const strategyBuilder = (plugin: InternalPlugin) => {
   }
 }
 
-export const finish = (user: Partial<User>) => {
+export const finish = (user: Partial<User>, shared: Shared) => {
   const basePath = retrieveBasePath()
   history = createBrowserHistory({basename: basePath})
-  const pluginMapper = pluginToQiankunMapper(user, basePath)
+  const pluginMapper = pluginToQiankunMapper(user, basePath, shared)
   const quiankunConfig = registeredPlugins
     .filter(plugin => plugin.integrationMode === INTEGRATION_METHODS.QIANKUN)
     .map<RegistrableApp<any>>(pluginMapper)
@@ -78,13 +79,14 @@ export const finish = (user: Partial<User>) => {
   start()
 }
 
-const pluginToQiankunMapper = (user: Partial<User>, basePath: string) => {
+const pluginToQiankunMapper = (user: Partial<User>, basePath: string, shared: Shared) => {
   return (plugin: InternalPlugin) => ({
     name: plugin.id,
     entry: plugin.pluginUrl || '',
     container: `#${MICROLC_QIANKUN_CONTAINER}`,
     activeRule: `${basePath}${plugin.pluginRoute || ''}`,
     props: {
+      ...(shared.props || {}),
       ...plugin.props,
       basePath,
       activeRule: `${basePath}${plugin.pluginRoute || ''}`,

--- a/packages/fe-container/src/utils/plugins/PluginsLoaderFacade.ts
+++ b/packages/fe-container/src/utils/plugins/PluginsLoaderFacade.ts
@@ -67,7 +67,7 @@ const strategyBuilder = (plugin: InternalPlugin) => {
   }
 }
 
-export const finish = (user: Partial<User>, shared: Shared) => {
+export const finish = (user: Partial<User>, shared: Shared = {}) => {
   const basePath = retrieveBasePath()
   history = createBrowserHistory({basename: basePath})
   const pluginMapper = pluginToQiankunMapper(user, basePath, shared)
@@ -86,7 +86,7 @@ const pluginToQiankunMapper = (user: Partial<User>, basePath: string, shared: Sh
     container: `#${MICROLC_QIANKUN_CONTAINER}`,
     activeRule: `${basePath}${plugin.pluginRoute || ''}`,
     props: {
-      ...(shared.props || {}),
+      ...shared?.props,
       ...plugin.props,
       basePath,
       activeRule: `${basePath}${plugin.pluginRoute || ''}`,


### PR DESCRIPTION
microlc might share configuration props to plugins.

in order to do that, BE config is expanded and `finish` calls on qiankun may receive an extra `shared` object.

tests were modified accordingly.